### PR TITLE
Fix/emoji parsing

### DIFF
--- a/emojiModifierCodeMap.go
+++ b/emojiModifierCodeMap.go
@@ -1,0 +1,10 @@
+package main
+
+// Mapping from character to concrete escape code.
+var emojiModifiers = map[string]string{
+	":skin-tone-1:": "\U0001f9d1\U0001f3fb",
+	":skin-tone-2:": "\U0001f9d1\U0001f3fc",
+	":skin-tone-3:": "\U0001f9d1\U0001f3fd",
+	":skin-tone-4:": "\U0001f9d1\U0001f3fe",
+	":skin-tone-5:": "\U0001f9d1\U0001f3ff",
+}

--- a/emojiModifierCodeMap.go
+++ b/emojiModifierCodeMap.go
@@ -1,7 +1,7 @@
 package main
 
 // Mapping from character to concrete escape code.
-var emojiModifiers = map[string]string{
+var emojiModifierCodeMap = map[string]string{
 	":skin-tone-1:": "\U0001f9d1\U0001f3fb",
 	":skin-tone-2:": "\U0001f9d1\U0001f3fc",
 	":skin-tone-3:": "\U0001f9d1\U0001f3fd",

--- a/emoji_parser.go
+++ b/emoji_parser.go
@@ -1,0 +1,35 @@
+package main
+
+// Parse an emoji with optional modifier from a string
+func parseEmoji(inputEmoji string) string {
+	emoji := strings.TrimSpace(inputEmoji)
+	// if slack emoji format
+	if strings.Index(emoji, ":") == 0 {
+		emoji = strings.ReplaceAll(inputEmoji, "️", "") // this removes Variation Selector-16 (https://emojipedia.org/variation-selector-16/)
+	}
+
+	//return emoji if it exists in default codemap
+	if emojiCodeMap[emoji] != "" {
+		emoji = emojiCodeMap[emoji]
+		return emoji
+	}
+
+	//check for modifier if emoji not found in default codemap
+	if emojiCodeMap[emoji] == "" {
+		arr := strings.Split(emoji, "::")
+		if len(arr) > 1 {
+			//modifier will always be the final code
+			modifier := ":" + arr[len(arr)-1]
+			parsedEmoji := arr[0] + ":"
+
+			_, hasEmoji := emojiCodeMap[parsedEmoji]
+			_, hasModifier := emojiModifiers[modifier]
+
+			if hasModifier && hasEmoji {
+				return emojiCodeMap[parsedEmoji] + emojiModifiers[modifier]
+			}
+		}
+	}
+
+	return ""
+}

--- a/emoji_parser.go
+++ b/emoji_parser.go
@@ -1,7 +1,9 @@
 package main
 
+import "strings"
+
 // Parse an emoji with optional modifier from a string
-func parseEmoji(inputEmoji string) string {
+func parseEmoji(inputEmoji string) (string, bool) {
 	emoji := strings.TrimSpace(inputEmoji)
 	// if slack emoji format
 	if strings.Index(emoji, ":") == 0 {
@@ -11,25 +13,23 @@ func parseEmoji(inputEmoji string) string {
 	//return emoji if it exists in default codemap
 	if emojiCodeMap[emoji] != "" {
 		emoji = emojiCodeMap[emoji]
-		return emoji
+		return emoji, true
 	}
 
 	//check for modifier if emoji not found in default codemap
-	if emojiCodeMap[emoji] == "" {
-		arr := strings.Split(emoji, "::")
-		if len(arr) > 1 {
-			//modifier will always be the final code
-			modifier := ":" + arr[len(arr)-1]
-			parsedEmoji := arr[0] + ":"
+	arr := strings.Split(emoji, "::")
+	if len(arr) > 1 {
+		//modifier will always be the final code
+		modifier := ":" + arr[len(arr)-1]
+		parsedEmoji := strings.ReplaceAll(emoji, modifier, "")
 
-			_, hasEmoji := emojiCodeMap[parsedEmoji]
-			_, hasModifier := emojiModifiers[modifier]
+		_, hasEmoji := emojiCodeMap[parsedEmoji]
+		_, hasModifier := emojiModifierCodeMap[modifier]
 
-			if hasModifier && hasEmoji {
-				return emojiCodeMap[parsedEmoji] + emojiModifiers[modifier]
-			}
+		if hasModifier && hasEmoji {
+			return emojiCodeMap[parsedEmoji] + emojiModifierCodeMap[modifier], true
 		}
 	}
 
-	return ""
+	return "", false
 }

--- a/emoji_parser_test.go
+++ b/emoji_parser_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestEmojiParserCorrectSingleEmoji(t *testing.T) {
+	_, contains := parseEmoji(":female-artist:")
+	if !contains {
+		t.Error("Does not contain emoji")
+	}
+}
+
+func TestEmojiParserCorrectDoubleEmojiWithModifier(t *testing.T) {
+	_, contains := parseEmoji(":female-artist::skin-tone-3:")
+	if !contains {
+		t.Error("Does not contain emoji")
+	}
+}
+
+func TestEmojiParserIncorrectDoubleEmojiWithModifier(t *testing.T) {
+	_, contains := parseEmoji(":dinosour-artist::skin-tone-3:")
+	if contains {
+		t.Error("Should not contain emoji code")
+	}
+}
+
+type testSyntax struct {
+	arg1     string
+	expected bool
+}
+
+var syntaxTests = []testSyntax{
+	{":female-artist:", true},
+	{"female-artist:", false},
+	{"::female-artist:", false},
+	{":female-artist:skin-tone-2:", false},
+	{":female-artist::skin-tone-2:", true},
+}
+
+func TestEmojiParserInputSyntax(t *testing.T) {
+	for _, test := range syntaxTests {
+		if _, contains := parseEmoji(test.arg1); contains != test.expected {
+			t.Error("Incorect syntax")
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -323,7 +323,7 @@ func brrr(userid string, text []string) string {
 
 	// throw error if no emoji is found
 	if !containsEmoji {
-		emojiError := fmt.Errorf("No emoji found while parsing %s", emoji)
+		emojiError := fmt.Errorf("No emoji found while parsing %s", text[1])
 		return emojiError.Error()
 	}
 
@@ -409,7 +409,7 @@ func send(userid string, text []string) string {
 	emoji, containsEmoji := parseEmoji(text[1])
 	// throw error if no emoji is found
 	if !containsEmoji {
-		emojiError := fmt.Errorf("No emoji found while parsing %s", emoji)
+		emojiError := fmt.Errorf("No emoji found while parsing %s", text[1])
 		return emojiError.Error()
 	}
 

--- a/main.go
+++ b/main.go
@@ -319,19 +319,8 @@ func brrr(userid string, text []string) string {
 	if err != nil {
 		return fmt.Sprintf("ERROR: %s (%s)", err.Error(), userid)
 	}
-	emoji := strings.TrimSpace(text[1])
+	emoji, _ := parseEmoji(text[1])
 
-	// if slack emoji format
-	if strings.Index(emoji, ":") == 0 {
-		emoji = strings.ReplaceAll(text[1], "️", "") // this removes Variation Selector-16 (https://emojipedia.org/variation-selector-16/)
-	}
-
-	fmt.Printf("emoji: '%s'\n", emoji)
-	fmt.Println("emojiCodeMap", emojiCodeMap[emoji])
-
-	if emojiCodeMap[emoji] != "" {
-		emoji = emojiCodeMap[emoji]
-	}
 	command := fmt.Sprintf("pooltoycli tx faucet mintfor $(pooltoycli keys show %s -a) %s --from %s -y", recipientID, emoji, senderID)
 	fmt.Printf("Try command '%s\n", command)
 
@@ -411,10 +400,7 @@ func send(userid string, text []string) string {
 		return fmt.Sprintf("ERROR: %s (%s)", err.Error(), userid)
 	}
 
-	emoji := text[1]
-	if emojiCodeMap[emoji] != "" {
-		emoji = emojiCodeMap[emoji]
-	}
+	emoji, _ := parseEmoji(text[1])
 	command := fmt.Sprintf("pooltoycli tx send %s $(pooltoycli keys show %s -a) 1%s --from %s -y", senderID, recipientID, emoji, senderID)
 	fmt.Printf("Try command '%s\n", command)
 

--- a/main.go
+++ b/main.go
@@ -319,7 +319,13 @@ func brrr(userid string, text []string) string {
 	if err != nil {
 		return fmt.Sprintf("ERROR: %s (%s)", err.Error(), userid)
 	}
-	emoji, _ := parseEmoji(text[1])
+	emoji, containsEmoji := parseEmoji(text[1])
+
+	// throw error if no emoji is found
+	if !containsEmoji {
+		emojiError := fmt.Errorf("No emoji found while parsing %s", emoji)
+		return emojiError.Error()
+	}
 
 	command := fmt.Sprintf("pooltoycli tx faucet mintfor $(pooltoycli keys show %s -a) %s --from %s -y", recipientID, emoji, senderID)
 	fmt.Printf("Try command '%s\n", command)
@@ -400,7 +406,13 @@ func send(userid string, text []string) string {
 		return fmt.Sprintf("ERROR: %s (%s)", err.Error(), userid)
 	}
 
-	emoji, _ := parseEmoji(text[1])
+	emoji, containsEmoji := parseEmoji(text[1])
+	// throw error if no emoji is found
+	if !containsEmoji {
+		emojiError := fmt.Errorf("No emoji found while parsing %s", emoji)
+		return emojiError.Error()
+	}
+
 	command := fmt.Sprintf("pooltoycli tx send %s $(pooltoycli keys show %s -a) 1%s --from %s -y", senderID, recipientID, emoji, senderID)
 	fmt.Printf("Try command '%s\n", command)
 


### PR DESCRIPTION
## Description
Closes https://github.com/interchainberlin/slackbot/issues/10

I have added an `emojiModifierCodeMap.go` file that contains different known modifiers. We can extend this in the future with other modifiers. 

The function `parseEmoji` checks to see if an emoji is found in the `emojiCodeMap`. If not it checks if there is a modifier attached to the emoji. If there is it checks if the `emoji` without the `modifier` exists in the `emojiCodeMap` and then checks if the `modifier` exists in `emojiModifierCodeMap`. If both exist it will generate a code for the emoji with the modifier. 

For example: `:female-artist::skin-tone-3:` will now work. 

Potential issue: if the modifier does not work with the emoji specified the code generated will be useless. I think this is ok as the person sending the emoji will be picking the emoji from slack, which will give feedback if the emoji exists or not. 

## How to test
Run the tests 

