### PR TITLE
removing adult codec from skin tone modifier

### DIFF
--- a/emojiModifierCodeMap.go
+++ b/emojiModifierCodeMap.go
@@ -2,9 +2,9 @@ package main
 
 // Mapping from character to concrete escape code.
 var emojiModifierCodeMap = map[string]string{
-	":skin-tone-1:": "\U0001f9d1\U0001f3fb",
-	":skin-tone-2:": "\U0001f9d1\U0001f3fc",
-	":skin-tone-3:": "\U0001f9d1\U0001f3fd",
-	":skin-tone-4:": "\U0001f9d1\U0001f3fe",
-	":skin-tone-5:": "\U0001f9d1\U0001f3ff",
+	":skin-tone-1:": "\U0001f3fb",
+	":skin-tone-2:": "\U0001f3fc",
+	":skin-tone-3:": "\U0001f3fd",
+	":skin-tone-4:": "\U0001f3fe",
+	":skin-tone-5:": "\U0001f3ff",
 }


### PR DESCRIPTION
Removing the human code in the `skin-tone` modifier codemap.