### PR TITLE
adding functionality to build emoji in the correct format

### DIFF
--- a/emoji_parser.go
+++ b/emoji_parser.go
@@ -1,6 +1,8 @@
 package main
 
-import "strings"
+import (
+	"strings"
+)
 
 // Parse an emoji with optional modifier from a string
 func parseEmoji(inputEmoji string) (string, bool) {
@@ -27,7 +29,14 @@ func parseEmoji(inputEmoji string) (string, bool) {
 		_, hasModifier := emojiModifierCodeMap[modifier]
 
 		if hasModifier && hasEmoji {
-			return emojiCodeMap[parsedEmoji] + emojiModifierCodeMap[modifier], true
+			baseEmoji := emojiCodeMap[parsedEmoji]
+			// \u200d is a seperator for combining emojis
+			indexOfSeperator := strings.Index(baseEmoji, "\u200d")
+			if indexOfSeperator == -1 {
+				return "", false
+			}
+			//build the emoji code in the correct format (seperator needs to come after the modifier)
+			return baseEmoji[:indexOfSeperator] + emojiModifierCodeMap[modifier] + baseEmoji[indexOfSeperator:], true
 		}
 	}
 


### PR DESCRIPTION
Building the final emoji in the correct format if a modifier is present. 

For example the emoji `:female-artist::skin-tone-1:` has the unicode value of `\U0001f469\U0001f3fb\u200d\U0001f3a8` .  The `u200d` code is a seperator that joins the emojis together. The modifier in this case is placed before the `u200d`. 