### PR TITLE
passing empty text array to balance function should not error

### DIFF
--- a/main.go
+++ b/main.go
@@ -304,7 +304,7 @@ func tilbrrr(userid string, text []string) string {
 		return fmt.Sprintf("ERROR: %s (%s)", err.Error(), userid)
 	}
 
-	if len(text) != 1 {
+	if len(text) != 1 || text[0] == "" {
 		return fmt.Sprintf("Sorry %s, I don't understand that command. Please follow the format '/til-brrr [user]'", senderUsername)
 	}
 
@@ -496,7 +496,7 @@ func balance(userid string, text []string) string {
 		return fmt.Sprintf("ERROR: %s (%s)", err.Error(), userid)
 	}
 
-	if len(text) != 1 {
+	if len(text) != 1 || text[0] == "" {
 		return fmt.Sprintf("Sorry %s, I don't understand that command. Please follow the format '/balance [user]'", senderUsername)
 	}
 


### PR DESCRIPTION
Slices of length 1 may also indicate that no matches were found in the source string in `strings.Split`
If the empty string is passed to `strings.Split`, the result will be a slice of length 1 containing the empty string.
See this [go playground example](https://play.golang.org/p/8GJvDGZEFVH). 

This fix guards against the case that an empty string was passed to the balance function by checking it explicitly.