### PR TITLE
output: drop processing messages

### DIFF
--- a/main.go
+++ b/main.go
@@ -98,18 +98,6 @@ func botHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Printf("textArray:'%s'\n", textArray)
 	fmt.Printf("textArray len:'%d'\n", len(textArray))
 
-	botReply := "Processing your request, please standby ⏳"
-	jsonResp, _ := json.Marshal(struct {
-		Type string `json:"response_type"`
-		Text string `json:"text"`
-	}{
-		Type: "in_channel",
-		Text: fmt.Sprintf("```%s```", botReply),
-	})
-
-	w.Header().Add("Content-Type", "application/json")
-	fmt.Fprintf(w, string(jsonResp))
-
 	go handleCommand(responseURL, command, userid, textArray)
 }
 


### PR DESCRIPTION
While it's useful for debugging, the latency on operations is low
enough that if we don't get a response in a few seconds, we know that
there's a problem, and otherwise acknowledging the message isn't
particularly useful and just makes it harder to look at slack channels
where pool toy is used.